### PR TITLE
Fix msvc address sanitizer link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ target_compile_features(project_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 
 # We don't have any way of ensuring that all static dependencies are compiled with
 # address sanitizer enabled.
-target_compile_definitions(project_options INTERFACE _DISABLE_VECTOR_ANNOTATION)
+target_compile_definitions(project_options INTERFACE _DISABLE_VECTOR_ANNOTATION _DISABLE_STRING_ANNOTATION)
 
 # configure files based on CMake configuration options
 add_subdirectory(configured_files)


### PR DESCRIPTION
Recently string annotations were added in msvc asan builds.

For
[cmake] -- The CXX compiler identification is MSVC 19.34.31721.0

I get error
[build] docopt.lib(docopt.obj) : error LNK2038: mismatch detected for 'annotate_string': value '0' doesn't match value '1' in main.cpp.obj
[...]
[build] src\travels.exe : fatal error LNK1319: 44 mismatches detected

We can simply disable the string annotations just like the vector annotations